### PR TITLE
Add instructions for installation from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Windows: `pip install GridCal-x.xx.tar.gz`
 
 OSX/Linux: `pip3 install GridCal-x.xx.tar.gz`
 
+## Installation from GitHub
+
+Although the actual `GridCal` package lives under `UnderDevelopment`, `pip` can still install it:
+
+    python3 -m pip install -e 'git+git://github.com/SanPen/GridCal.git#egg=GridCal&subdirectory=UnderDevelopment'
+
+Installing `GridCal` from GitHub, `pip` can still freeze the version using a commit hash:
+
+    python -m pip install -e 'git+git://github.com/SanPen/GridCal.git@5c4dcb96998ae882412b5fee977cf0cff7a40d3c#egg=GridCal&subdirectory=UnderDevelopment'
+
 # Run with user interface
 
 From a Python console:


### PR DESCRIPTION
This way has potentially more current software, retains the possibility to freeze the package and still is more automated than installing from the source.