### PR TITLE
Adjusted and tested the resistance temperature correction

### DIFF
--- a/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
+++ b/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
@@ -63,7 +63,7 @@ class PowerFlowOptions:
     def __init__(self, solver_type: SolverType = SolverType.NR, aux_solver_type: SolverType = SolverType.HELM,
                  verbose=False, robust=False, initialize_with_existing_solution=True,
                  tolerance=1e-6, max_iter=25, control_q=False, multi_core=False, dispatch_storage=False,
-                 control_taps=False, control_p=False, apply_temperature_correction=False):
+                 control_taps=False, control_p=False):
         """
         Power flow execution options
         @param solver_type:
@@ -76,7 +76,6 @@ class PowerFlowOptions:
         @param max_iter:
         @param control_q:
         @param control_taps:
-        @param apply_temperature_correction: Apply the temperature correction to the resistance of the branches?
         """
         self.solver_type = solver_type
 
@@ -101,8 +100,6 @@ class PowerFlowOptions:
         self.dispatch_storage = dispatch_storage
 
         self.control_taps = control_taps
-
-        self.apply_temperature_correction = apply_temperature_correction
 
 
 class PowerFlowMP:
@@ -935,7 +932,7 @@ class PowerFlowMP:
 
         # print('Compiling...', end='')
         numerical_circuit = self.grid.compile()
-        calculation_inputs = numerical_circuit.compute(apply_temperature=self.options.apply_temperature_correction)
+        calculation_inputs = numerical_circuit.compute()
 
         if len(numerical_circuit.islands) > 1:
 

--- a/UnderDevelopment/tests/test_cable_temp.py
+++ b/UnderDevelopment/tests/test_cable_temp.py
@@ -1,0 +1,27 @@
+from GridCal.Engine.Devices import *
+
+test_name = "test_cable_temp"
+
+def test_cable_temp():
+    """
+    Very simple test to validate the effect of cable temperature on a cable's
+    resistance.
+    """
+
+    # Create buses
+    B_C3 = Bus(name="B_C3",
+               vnom=10) #kV
+
+    B_MV_M32 = Bus(name="B_MV_M32",
+                   vnom=10) #kV
+
+    cable = Branch(bus_from=B_C3,
+                   bus_to=B_MV_M32,
+                   name="C_M32",
+                   r=0.784,
+                   x=0.174,
+                   Tb=20, # °C
+                   Tc=90, # °C
+                   k=ThermalConstant.Copper)
+
+    assert round(cable.R, 4) == 0.9613


### PR DESCRIPTION
Hi Santiago,

In reference to #32.

I think this should be handled at the Devices.Branch level, not at the MultiCircuit level. We usually make this adjustement only for cables and lines, not transformers, and all conductors won't necessarily operate at the same temperature.

The formula you have provided in #32 is good. The one used by ETAP came from Southwire, who explained that it was developped from [yours](https://www.cirris.com/learning-center/general-testing/special-topics/177-temperature-coefficient-of-copper). Yours, however, can easily be found in other sources, including [Wikipedia](https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity#Temperature_dependence) and the US' National Electrical Code (NFPA 70).

For the material thermal constant, I used those provided in footnote 2 of table 8 from the 2005 NEC for copper and aluminum at 75°C. As [Wikipedia](https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity#Temperature_dependence) explains, those constant are not entirely linear so they should be taken closer to the expected operating temperature to improve accuracy, and the NEC is as good a reference as it gets (P.S.: Southwire had constants at 25°C).

I created an Enum for the ThermalConstant, and run Branch.apply_temperature() at its __init__() if the branch's Tb and Tc are different.

Open for discussion, as always. Thanks. If we wanted to overcomplicate things we could define constants at different reference temperatures, and use the one closes to Tb and Tc for our resistance correction, but that might be overkill.