### PR TITLE
Added logistic function to get a variable gain for iterative Q control

### DIFF
--- a/UnderDevelopment/tests/test_pv_3.py
+++ b/UnderDevelopment/tests/test_pv_3.py
@@ -1,5 +1,5 @@
 from GridCal.Engine.PowerFlowDriver import PowerFlowOptions, SolverType, ReactivePowerControlMode
-from GridCal.Engine.PowerFlowDriver import PowerFlow, IterationMethod
+from GridCal.Engine.PowerFlowDriver import PowerFlow
 from GridCal.Engine.CalculationEngine import MultiCircuit
 from GridCal.Engine.Devices import *
 from GridCal.Engine.DeviceTypes import *
@@ -127,7 +127,6 @@ def test_pv_3():
                                multi_core=True,
                                control_q=ReactivePowerControlMode.Iterative,
                                control_taps=True,
-                               iterative_pv_method=IterationMethod.FAST,
                                tolerance=1e-6,
                                max_iter=99)
 


### PR DESCRIPTION
Replaced the static increment with a [logistic function](https://en.wikipedia.org/wiki/Logistic_function) that calculates a gain based on the difference between the current voltage `Vm[i]` and the setpoint `Vset[i]`. The increment is then calculated by multiplying this gain by the difference between the applicable Qlimit (either `Qmax[i]` or `Qmin[i]`) and `Q[i]`. The gain can vary from 0 (at `Vm[i] == Vset[i]`) and 1 (at `Vset[i] - Vm[i] == inf`).

This speeds up my findfarm analysis significantly, from 72 outer iterations (in #43) to only 15!!! Raising the steepness factor `k` doesn't speed things up any further and I fear it could lead to unstability in some cases, thoughI didn't encounter any instability.

`test_pv_3.py` has been adapted and still succeeds (in 7 outer iterations).

This PR also removes the need for the `iterative_pv_method` option.

That was a fun weekend!