### PR TITLE
Tweaked the steepness and precision

### DIFF
--- a/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
+++ b/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
@@ -558,7 +558,7 @@ class PowerFlowMP:
         Vnew = V.copy()
         types_new = types.copy()
         any_control_issue = False
-        precision = 5 # Could be tweaked
+        precision = 4
 
 #        if verbose:
 #            print(f"Q = {Q}")

--- a/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
+++ b/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
@@ -527,7 +527,7 @@ class PowerFlowMP:
 
         The steepness factor k was set through trial an error.
         """
-        k = 100
+        k = 10
         return 2 * (1 / (1 + exp(-k * abs(V2 - V1))) - 0.5)
 
     def iterate_pv_control(self, V, Vset, Q, Qmax, Qmin, types, original_types, verbose):
@@ -558,7 +558,7 @@ class PowerFlowMP:
         Vnew = V.copy()
         types_new = types.copy()
         any_control_issue = False
-        precision = 4 # Could be tweaked
+        precision = 5 # Could be tweaked
 
 #        if verbose:
 #            print(f"Q = {Q}")

--- a/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
+++ b/UnderDevelopment/GridCal/Engine/PowerFlowDriver.py
@@ -527,7 +527,7 @@ class PowerFlowMP:
 
         The steepness factor k was set through trial an error.
         """
-        k = 10
+        k = 30
         return 2 * (1 / (1 + exp(-k * abs(V2 - V1))) - 0.5)
 
     def iterate_pv_control(self, V, Vset, Q, Qmax, Qmin, types, original_types, verbose):


### PR DESCRIPTION
I did encounter instability during one of my network simulations with the steepness factor k at 100, and I finally settled on 30.

`test_pv_3.py` settles in 16 iterations. Strangely enough, my network with 46 generators controlled this way settles in just 11 iterations, but it gets unstable with a k factor of 40 or higher.

If we encounter problems in the future with these parameters, the solution would probably be to expose them as options.