### PR TITLE
Added file to link to doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Please refer to the
+[*Development* section of the official documentation](https://gridcal.readthedocs.io/en/master/development.html).
+


### PR DESCRIPTION
Simply created CONTRIBUTING.md and linked to the appropriate section of the documentation. I think most contributors would expect to find this file in the root directory.