### PR TITLE
Removed unecessary grid.compile(); import cleanup

### DIFF
--- a/src/tests/test_branch_tolerance.py
+++ b/src/tests/test_branch_tolerance.py
@@ -1,7 +1,4 @@
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowOptions, PowerFlow
-from GridCal.Engine.Core.multi_circuit import MultiCircuit
-from GridCal.Engine.basic_structures import BranchImpedanceMode
-from GridCal.Engine.devices import Bus, Branch, Generator, Load
+from GridCal.Engine import *
 
 Sbase = 100  # MVA
 
@@ -35,7 +32,6 @@ def test_tolerance_lf_higher():
                            tolerance=10))
 
     # Run non-linear power flow
-    grid.compile()
     options = PowerFlowOptions(verbose=True,
                                branch_impedance_tolerance_mode=BranchImpedanceMode.Upper)
 
@@ -127,7 +123,6 @@ def test_tolerance_lf_lower():
                            tolerance=10))
 
     # Run non-linear power flow
-    grid.compile()
     options = PowerFlowOptions(verbose=True,
                                branch_impedance_tolerance_mode=BranchImpedanceMode.Lower)
 

--- a/src/tests/test_line_losses.py
+++ b/src/tests/test_line_losses.py
@@ -1,6 +1,4 @@
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowOptions, PowerFlow
-from GridCal.Engine.Core.multi_circuit import MultiCircuit
-from GridCal.Engine.devices import *
+from GridCal.Engine import *
 
 Sbase = 100  # MVA
 
@@ -32,7 +30,6 @@ def test_line_losses_1():
     grid.add_branch(Branch(bus_from=Bus0, bus_to=Bus1, name="Cable1", r=0.01, x=0.05))
 
     # Run non-linear load flow
-    grid.compile()
     options = PowerFlowOptions(verbose=True)
 
     power_flow = PowerFlow(grid, options)
@@ -115,7 +112,6 @@ def test_line_losses_2():
     grid.add_branch(Branch(bus_from=Bus1, bus_to=Bus2, name="Cable1", r=0.005, x=0.025))
 
     # Run non-linear load flow
-    grid.compile()
     options = PowerFlowOptions(verbose=True)
 
     power_flow = PowerFlow(grid, options)
@@ -197,7 +193,6 @@ def test_line_losses_3():
     grid.add_branch(Branch(bus_from=Bus0, bus_to=Bus1, name="Cable1", r=0.02, x=0.1))
 
     # Run non-linear load flow
-    grid.compile()
     options = PowerFlowOptions(verbose=True)
 
     power_flow = PowerFlow(grid, options)

--- a/src/tests/test_power_flow.py
+++ b/src/tests/test_power_flow.py
@@ -1,8 +1,4 @@
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowOptions, SolverType, ReactivePowerControlMode
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlow
-from GridCal.Engine.Core.multi_circuit import MultiCircuit
-from GridCal.Engine.devices import *
-from GridCal.Engine.device_types import *
+from GridCal.Engine import *
 
 Sbase = 100  # MVA
 
@@ -122,7 +118,6 @@ def test_basic():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,
@@ -274,7 +269,6 @@ def test_gridcal_basic_pi():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,

--- a/src/tests/test_temp_correction.py
+++ b/src/tests/test_temp_correction.py
@@ -1,6 +1,4 @@
-from GridCal.Engine.devices import *
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowOptions, PowerFlow
-from GridCal.Engine.Core.multi_circuit import MultiCircuit
+from GridCal.Engine import *
 
 from pytest import approx
 
@@ -78,8 +76,6 @@ def test_corr_line_losses():
 
     grid.add_branch(cable)
 
-    # Run non-linear load flow
-    grid.compile()
     options = PowerFlowOptions(verbose=True,
                                apply_temperature_correction=True)
 

--- a/src/tests/test_transformer_regulator.py
+++ b/src/tests/test_transformer_regulator.py
@@ -1,8 +1,4 @@
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowOptions, SolverType, ReactivePowerControlMode
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowMP, TapsControlMode
-from GridCal.Engine.Core.multi_circuit import MultiCircuit
-from GridCal.Engine.devices import *
-from GridCal.Engine.device_types import *
+from GridCal.Engine import *
 
 Sbase = 100  # MVA
 
@@ -121,7 +117,6 @@ def test_gridcal_regulator():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,

--- a/src/tests/test_transformer_static_taps.py
+++ b/src/tests/test_transformer_static_taps.py
@@ -1,10 +1,7 @@
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowOptions, SolverType, ReactivePowerControlMode
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlow
-from GridCal.Engine.Core.multi_circuit import MultiCircuit
-from GridCal.Engine.devices import *
-from GridCal.Engine.device_types import *
+from GridCal.Engine import *
 
 Sbase = 100 # MVA
+
 
 def complex_impedance(z, XR):
     """
@@ -118,7 +115,6 @@ def test_xfo_static_tap_1():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,
@@ -270,7 +266,6 @@ def test_xfo_static_tap_2():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,

--- a/src/tests/test_voltage_controlled_generator.py
+++ b/src/tests/test_voltage_controlled_generator.py
@@ -1,8 +1,4 @@
-from GridCal.Engine.Drivers.power_flow_driver import PowerFlowOptions, SolverType, PowerFlow
-from GridCal.Engine.Drivers.power_flow_driver import ReactivePowerControlMode, TapsControlMode
-from GridCal.Engine.Core.multi_circuit import MultiCircuit
-from GridCal.Engine.devices import *
-from GridCal.Engine.device_types import *
+from GridCal.Engine import *
 
 Sbase = 100 # MVA
 
@@ -113,7 +109,6 @@ def test_pv_1():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,
@@ -264,7 +259,6 @@ def test_pv_2():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,
@@ -419,7 +413,6 @@ def test_pv_3():
         print(f" - bus[{i}]: {b}")
     print()
 
-    grid.compile()
     options = PowerFlowOptions(SolverType.LM,
                                verbose=True,
                                initialize_with_existing_solution=True,


### PR DESCRIPTION
Calling grid.compile() before running the PF is redundant; PowerFlowMP.run() does it already.