### PR TITLE
change error message on newton native

### DIFF
--- a/src/GridCal/Engine/Core/Compilers/circuit_to_newton.py
+++ b/src/GridCal/Engine/Core/Compilers/circuit_to_newton.py
@@ -16,7 +16,7 @@ except ImportError:
     newton_solver_dict = dict()
     newton_taps_dict = dict()
     newton_q_control_dict = dict()
-    print('Newton native unavailable')
+    print('Newton native is not available')
 
 
 def set_branch_values(nc: "nn.NativeNumericCircuit",


### PR DESCRIPTION
Default message:

```
Bentayga is not available
Newton native unavailable
```

That message is inconsistent.

Changed to

```
Bentayga is not available
Newton native is not available
```