### PR TITLE
ignore .egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ __pycache__
 
 /build
 /dist
-/GridCal.egg-info
+*.egg-info
 
 /src/tests/data/output/*.png
 


### PR DESCRIPTION
for installing using:

```
cd src
pip install -e .
```