### PR TITLE
fix_tm_might_be_empty

### DIFF
--- a/src/GridCal/Engine/Simulations/PowerFlow/power_flow_results.py
+++ b/src/GridCal/Engine/Simulations/PowerFlow/power_flow_results.py
@@ -540,7 +540,10 @@ class PowerFlowResults(ResultsTemplate):
         la = self.losses.real
         lr = self.losses.imag
         ls = np.abs(self.losses)
-        tm = self.transformer_tap_module
+        if self.transformer_tap_module.size == 0:
+            tm = [np.nan] * sr.size
+        else:
+            tm = self.transformer_tap_module
 
         branch_data = np.c_[sr, si, sm, ld, la, lr, ls, tm]
         branch_cols = ['Real power (MW)',


### PR DESCRIPTION
fix tm might be empty and cause mismatch dimension error in numpy concatenate.