### PR TITLE
move compiler print to logger

### DIFF
--- a/src/GridCal/Engine/Core/Compilers/circuit_to_bentayga.py
+++ b/src/GridCal/Engine/Core/Compilers/circuit_to_bentayga.py
@@ -10,6 +10,8 @@ from GridCal.Engine.basic_structures import Logger, SolverType, ReactivePowerCon
 from GridCal.Engine.Simulations.PowerFlow.power_flow_options import PowerFlowOptions
 from GridCal.Engine.IO.file_system import get_create_gridcal_folder
 
+import logging
+logger = logging.getLogger(__name__)
 
 try:
     import bentayga as btg
@@ -18,24 +20,24 @@ try:
     if not btg.is_license_activated():
         btg_license = os.path.join(get_create_gridcal_folder(), 'bentayga.lic')
         if os.path.exists(btg_license):
-            # print('Bentayga v' + btg.get_version())
+            # logger.info('Bentayga v' + btg.get_version())
             btg.activate_license(btg_license)
             if btg.is_license_activated():
                 BENTAYGA_AVAILABLE = True
             else:
-                print('Bentayga v' + btg.get_version(),
+                logger.info('Bentayga v' + btg.get_version(),
                       "installed, tried to activate with {} but the license did not work :/".format(btg_license))
                 BENTAYGA_AVAILABLE = False
         else:
-            print('Bentayga v' + btg.get_version(), "installed but not licensed")
+            logger.info('Bentayga v' + btg.get_version(), "installed but not licensed")
             BENTAYGA_AVAILABLE = False
     else:
-        print('Bentayga v' + btg.get_version())
+        logger.info('Bentayga v' + btg.get_version())
         BENTAYGA_AVAILABLE = True
 
 except ImportError:
     BENTAYGA_AVAILABLE = False
-    print('Bentayga is not available')
+    logger.info('Bentayga is not available')
 
 # numpy integer type for bentayga's uword
 BINT = np.ulonglong

--- a/src/GridCal/Engine/Core/Compilers/circuit_to_newton.py
+++ b/src/GridCal/Engine/Core/Compilers/circuit_to_newton.py
@@ -6,17 +6,20 @@ from GridCal.Engine.basic_structures import BusMode
 from GridCal.Engine.Devices.enumerations import ConverterControlType, TransformerControlType
 from GridCal.Engine.Simulations.PowerFlow.power_flow_options import PowerFlowOptions
 
+import logging
+logger = logging.getLogger(__name__)
+
 try:
     import NewtonNative as nn
     NEWTON_AVAILBALE = True
-    print('Newton Native v' + nn.get_version())
+    logger.info('Newton Native v' + nn.get_version())
 
 except ImportError:
     NEWTON_AVAILBALE = False
     newton_solver_dict = dict()
     newton_taps_dict = dict()
     newton_q_control_dict = dict()
-    print('Newton native is not available')
+    logger.info('Newton native is not available')
 
 
 def set_branch_values(nc: "nn.NativeNumericCircuit",


### PR DESCRIPTION
It is annoying if we don't have `Bentayga` and `Newton native` since stdout is populated for every successful import:

```
Bentayga is not available
Newton native is not available
```

So, I move it to `logger.info()`.