### PR TITLE
Also copy opex and capex when cloning a line

### DIFF
--- a/src/GridCal/Engine/Devices/line.py
+++ b/src/GridCal/Engine/Devices/line.py
@@ -435,7 +435,9 @@ class Line(EditableDevice):
                  temp_base=self.temp_base,
                  temp_oper=self.temp_oper,
                  alpha=self.alpha,
-                 template=self.template)
+                 template=self.template,
+                 opex=self.opex,
+                 capex=self.capex)
 
         b.measurements = self.measurements
 


### PR DESCRIPTION
Currently the `copy` methods on devices ignore the `opex` and `capex` properties. This fixes this inconsistency for `Line`s, but should be added to all the other devices in the future.